### PR TITLE
Display YaLafi errors as warning notification

### DIFF
--- a/lib/linter-yalafi.js
+++ b/lib/linter-yalafi.js
@@ -231,8 +231,8 @@ export default {
         if (filteredErrors) {
           console.log(messageYaLafi + ':\n' + data.stderr);
           if (Array.from(this.activeNotifications).some(item =>
-            item.getOptions().detail === data.stderr
-            && item.getMessage() == messageYaLafi
+            item.reason == 'YaLafiError' + editor.getPath()
+            && item.getOptions().detail === data.stderr
             )) {
             // This message is still showing to the user!
           } else {
@@ -252,6 +252,7 @@ export default {
               }
             );
             notification.onDidDismiss(() => this.activeNotifications.delete(notification))
+            notification.reason =  'YaLafiError' + editor.getPath();
             this.activeNotifications.add(notification);
           }
           return null;
@@ -261,7 +262,7 @@ export default {
         // Dismiss all YaLafi related notifications for this file
         // if YaLafi works again:
         this.activeNotifications.forEach((notification) => {
-          if (notification.getMessage() === messageYaLafi) {
+          if (notification.reason === 'YaLafiError' + editor.getPath()) {
             notification.dismiss()
           }
         })

--- a/lib/linter-yalafi.js
+++ b/lib/linter-yalafi.js
@@ -155,11 +155,12 @@ export default {
         let eoLisCRLF = false;
         if (textBuffer.lineEndingForRow() == "\r\n") {
           eoLisCRLF = true;
-          const messageCRLF = "Change line seperators in " + editor.getTitle();
+          const messageCRLF = "Change line seperators in " + editor.getLongTitle();
           if (!this.disableCRLFWarning) {
             if (Array.from(this.activeNotifications).some(item =>
-              item.getMessage() === messageCRLF
+              item.reason === 'CRLFWarning' + editor.getPath()
             )) {
+              // console.log('linter-yalafi: ' + messageCRLF)
               // This message is still showing to the user!
             } else {
               const notification = atom.notifications.addWarning(
@@ -182,10 +183,11 @@ export default {
                       },
                       text: "Don't ask again"
                     },
-                  ],
+                  ]
                 }
               );
-              notification.onDidDismiss(() => this.activeNotifications.delete(notification))
+              notification.reason = 'CRLFWarning' + editor.getPath();
+              notification.onDidDismiss(() => this.activeNotifications.delete(notification));
               this.activeNotifications.add(notification);
             }
           }
@@ -225,7 +227,7 @@ export default {
 
         //console.log(data.stderr)
         const filteredErrors = filterWhitelistedErrors(data.stderr);
-        const messageYaLafi = 'YaLafi exited with error in ' + editor.getTitle();
+        const messageYaLafi = 'YaLafi exited with error in ' + editor.getLongTitle();
 
         // Show a warning if YaLafi exists with an error:
         if (filteredErrors) {
@@ -233,7 +235,7 @@ export default {
           if (Array.from(this.activeNotifications).some(item =>
             item.reason == 'YaLafiError' + editor.getPath()
             && item.getOptions().detail === data.stderr
-            )) {
+          )) {
             // This message is still showing to the user!
           } else {
             const notification = atom.notifications.addWarning(

--- a/lib/linter-yalafi.js
+++ b/lib/linter-yalafi.js
@@ -155,31 +155,39 @@ export default {
         let eoLisCRLF = false;
         if (textBuffer.lineEndingForRow() == "\r\n") {
           eoLisCRLF = true;
-
+          const messageCRLF = "Change line seperators in " + editor.getTitle();
           if (!this.disableCRLFWarning) {
-            let notification = atom.notifications.addWarning(
-              "Change line seperators in " + editor.getTitle(),
-              {
-                dismissable: true,
-                description: "Linter-YaLafi detected that your line breaks are set to CRLF. This might cause errors to the placement of the linter errors. Do you want change the document to LF?",
-                buttons: [
-                  {
-                    onDidClick: function(){
-                      atom.commands.dispatch(atom.views.getView(editor), "line-ending-selector:convert-to-LF");
-                      notification.dismiss();
+            if (Array.from(this.activeNotifications).some(item =>
+              item.getMessage() === messageCRLF
+            )) {
+              // This message is still showing to the user!
+            } else {
+              const notification = atom.notifications.addWarning(
+                messageCRLF,
+                {
+                  dismissable: true,
+                  description: "Linter-YaLafi detected that your line breaks are set to CRLF. This might cause errors to the placement of the linter errors. Do you want change the document to LF?",
+                  buttons: [
+                    {
+                      onDidClick: function(){
+                        atom.commands.dispatch(atom.views.getView(editor), "line-ending-selector:convert-to-LF");
+                        notification.dismiss();
+                      },
+                      text: "Change to LF"
                     },
-                    text: "Change to LF"
-                  },
-                  {
-                    onDidClick: function(){
-                      atom.config.set('linter-yalafi.disableCRLFWarning', true);
-                      notification.dismiss();
+                    {
+                      onDidClick: function(){
+                        atom.config.set('linter-yalafi.disableCRLFWarning', true);
+                        notification.dismiss();
+                      },
+                      text: "Don't ask again"
                     },
-                    text: "Don't ask again"
-                  },
-                ],
-              }
-            );
+                  ],
+                }
+              );
+              notification.onDidDismiss(() => this.activeNotifications.delete(notification))
+              this.activeNotifications.add(notification);
+            }
           }
         }
 

--- a/lib/linter-yalafi.js
+++ b/lib/linter-yalafi.js
@@ -81,6 +81,8 @@ const categries_map = {
 
 export default {
   activate() {
+    this.activeNotifications = new Set();
+
     this.subscriptions = new CompositeDisposable();
 
     this.subscriptions.add(atom.config.observe('linter-yalafi.language', (value) => {
@@ -129,6 +131,8 @@ export default {
   },
 
   deactivate() {
+    this.activeNotifications.forEach(notification => notification.dismiss())
+    this.activeNotifications.clear()
     this.subscriptions.dispose();
   },
 
@@ -213,11 +217,46 @@ export default {
 
         //console.log(data.stderr)
         const filteredErrors = filterWhitelistedErrors(data.stderr);
+        const messageYaLafi = 'YaLafi exited with error in ' + editor.getTitle();
+
+        // Show a warning if YaLafi exists with an error:
         if (filteredErrors) {
-          throw new Error(filteredErrors);
+          console.log(messageYaLafi + ':\n' + data.stderr);
+          if (Array.from(this.activeNotifications).some(item =>
+            item.getOptions().detail === data.stderr
+            && item.getMessage() == messageYaLafi
+            )) {
+            // This message is still showing to the user!
+          } else {
+            const notification = atom.notifications.addWarning(
+              messageYaLafi,
+              {
+                dismissable: true,
+                detail: data.stderr,
+                buttons: [
+                  {
+                    text: 'Cancel',
+                    onDidClick: () => {
+                      notification.dismiss()
+                    },
+                  },
+                ],
+              }
+            );
+            notification.onDidDismiss(() => this.activeNotifications.delete(notification))
+            this.activeNotifications.add(notification);
+          }
+          return null;
         }
 
         const lineRegex = /(\d+),(\d+),(\w+),(\w\d+):(.*)\r?(?:\n|$)/g;
+        // Dismiss all YaLafi related notifications for this file
+        // if YaLafi works again:
+        this.activeNotifications.forEach((notification) => {
+          if (notification.getMessage() === messageYaLafi) {
+            notification.dismiss()
+          }
+        })
 
         let matches = JSON.parse(data.stdout).matches;
         let messages = []

--- a/lib/linter-yalafi.js
+++ b/lib/linter-yalafi.js
@@ -225,7 +225,7 @@ export default {
           return null;
         }
 
-        //console.log(data.stderr)
+        // console.log(data)
         const filteredErrors = filterWhitelistedErrors(data.stderr);
         const messageYaLafi = 'YaLafi exited with error in ' + editor.getLongTitle();
 
@@ -257,17 +257,20 @@ export default {
             notification.reason =  'YaLafiError' + editor.getPath();
             this.activeNotifications.add(notification);
           }
-          return null;
+          if (data.exitCode !== 0) {
+            return null;
+          }
+        } else {
+          // Dismiss all YaLafi related notifications for this file
+          // if YaLafi works again:
+          this.activeNotifications.forEach((notification) => {
+            if (notification.reason === 'YaLafiError' + editor.getPath()) {
+              notification.dismiss()
+            }
+          })
         }
 
         const lineRegex = /(\d+),(\d+),(\w+),(\w\d+):(.*)\r?(?:\n|$)/g;
-        // Dismiss all YaLafi related notifications for this file
-        // if YaLafi works again:
-        this.activeNotifications.forEach((notification) => {
-          if (notification.reason === 'YaLafiError' + editor.getPath()) {
-            notification.dismiss()
-          }
-        })
 
         let matches = JSON.parse(data.stdout).matches;
         let messages = []


### PR DESCRIPTION
This pull request aims at the following:
- display YaLafi errors to the user via a warning notification
- remove all YaLafi error notifications for a file if YaLafi runs without errors again
- show YaLafi results, even if YaLafi has an error
- only show the same warning once at a time
- use `TextEditor.getLongTitle()` to distinguish warnings for different files with same name