### PR TITLE
set cwd correctly

### DIFF
--- a/lib/linter-yalafi.js
+++ b/lib/linter-yalafi.js
@@ -8,6 +8,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable } from 'atom';
 import path from 'path';
+import MagicParser from './magic-parser/magic-parser'
 
 const fs = require('fs');
 const lazyReq = require('lazy-req')(require);
@@ -21,6 +22,15 @@ const errorWhitelist = [
   /^\*\*\* yalafi.shell: warning:/,
   /^\*\*\* could not load module/
 ];
+
+const findRoot = (filePath) => {
+  const magic = new MagicParser(filePath).parse();
+  if (magic.root) {
+    return path.resolve(dirname(filePath), magic.root);
+  }
+  return filePath;
+}
+
 
 const getProjectDir = (filePath) => {
   const atomProject = atom.project.relativizePath(filePath)[0];
@@ -149,6 +159,10 @@ export default {
         const textBuffer = editor.getBuffer();
         const projectDir = getProjectDir(filePath);
         //const cwd = fixPathString(this.workingDirectory, fileDir, projectDir);
+
+        cwd = dirname(findRoot(filePath));
+        console.log(cwd);
+
         const env = Object.create(process.env);
 
         // Warnung notification if endOfLine is set to CRLF
@@ -214,7 +228,7 @@ export default {
         args.push(...this.yalafiOptions);
         args.push(filePath);
 
-        const execOpts = { env,/* cwd,*/ stream: 'both', timeout: 30000 };
+        const execOpts = { env, cwd, stream: 'both', timeout: 30000 };
         if (this.disableTimeout) {
           execOpts.timeout = Infinity;
         }

--- a/lib/magic-parser/magic-parser.js
+++ b/lib/magic-parser/magic-parser.js
@@ -1,0 +1,45 @@
+/** @babel */
+
+/**
+  This file is copied from thomasjo/atom-latex/lib/parsers/magic-parsers.js
+*/
+
+import Parser from './parser.js'
+
+/* eslint-disable no-multi-spaces */
+
+const MAGIC_COMMENT_PATTERN = new RegExp('' +
+  '^%\\s*' +    // Optional whitespace.
+  '!T[Ee]X' +   // Magic marker.
+  '\\s+' +      // Semi-optional whitespace.
+  '(\\w+)' +    // [1] Captures the magic keyword. E.g. 'root'.
+  '\\s*=\\s*' + // Equal sign wrapped in optional whitespace.
+  '(.*)' +      // [2] Captures everything following the equal sign.
+  '$'           // EOL.
+)
+
+const LATEX_COMMAND_PATTERN = new RegExp('' +
+  '\\' +                      // starting command \
+  '\\w+' +                    // command name e.g. input
+  '(\\{|\\w|\\}|/|\\]|\\[)*'  // options to the command
+)
+
+/* eslint-enable no-multi-spaces */
+
+export default class MagicParser extends Parser {
+  parse () {
+    const result = {}
+    const lines = this.getLines([])
+    for (const line of lines) {
+      const latexCommandMatch = line.match(LATEX_COMMAND_PATTERN)
+      if (latexCommandMatch) { break } // Stop parsing if a latex command was found
+
+      const match = line.match(MAGIC_COMMENT_PATTERN)
+      if (match != null) {
+        result[match[1]] = match[2].trim()
+      }
+    }
+
+    return result
+  }
+}

--- a/lib/magic-parser/parser.js
+++ b/lib/magic-parser/parser.js
@@ -1,0 +1,26 @@
+/** @babel */
+
+/**
+  This file is copied from thomasjo/atom-latex/lib/parser.js
+*/
+
+import fs from 'fs-plus'
+
+export default class Parser {
+  constructor (filePath) {
+    this.filePath = filePath
+  }
+
+  parse () {}
+
+  getLines (defaultLines) {
+    if (!fs.existsSync(this.filePath)) {
+      if (defaultLines) return defaultLines
+      throw new Error(`No such file: ${this.filePath}`)
+    }
+
+    const rawFile = fs.readFileSync(this.filePath, {encoding: 'utf-8'})
+    const lines = rawFile.replace(/(\r\n)|\r/g, '\n').split('\n')
+    return lines
+  }
+}

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
   "dependencies": {
     "atom-linter": "10.0.0",
     "atom-package-deps": "5.1.0",
-    "lazy-req": "2.0.0"
+    "lazy-req": "2.0.0",
+    "fs-plus": "^3.0.0"
   },
   "package-deps": [
     "linter:2.0.0"


### PR DESCRIPTION
This is a first attempt to set the cwd correctly.

So far cwd is set to the directory of the current file, or to the directory of the root file specified via `% !TeX root = file.tex`. That is what I intended in #17.

To implement the capturing of the magic command `% !TeX root = file.tex` I copied the needed classes from [thomasjo/atom-latex](https://github.com/thomasjo/atom-latex). Is there an option to load them from the installed package? And is that desirable?

Are there other use cases that should be implemented?

__To-Do__

- [ ] Implement other use cases if they exist
- [ ] Write documentation